### PR TITLE
Feat: Add optional Effects & Tools section with EQ, Compressor, Rever…

### DIFF
--- a/frontend/react-app/src/components/CompressorControls.js
+++ b/frontend/react-app/src/components/CompressorControls.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { FormGroup, Fieldset } from '../styles/App.styles'; // Assuming Fieldset provides a good card-like container
+
+const CompressorControls = ({
+  threshold, onThresholdChange,
+  ratio, onRatioChange,
+  attack, onAttackChange,
+  release, onReleaseChange,
+  isLoading
+}) => {
+  return (
+    <Fieldset>
+      <legend>Compressor</legend>
+      <FormGroup>
+        <label htmlFor="compressorThreshold">Threshold: {threshold.toFixed(1)} dB</label>
+        <input
+          type="range"
+          id="compressorThreshold"
+          min="-60"
+          max="0"
+          step="0.5"
+          value={threshold}
+          onChange={onThresholdChange}
+          disabled={isLoading}
+        />
+      </FormGroup>
+      <FormGroup>
+        <label htmlFor="compressorRatio">Ratio: {ratio.toFixed(1)}:1</label>
+        <input
+          type="range"
+          id="compressorRatio"
+          min="1"
+          max="20"
+          step="0.1"
+          value={ratio}
+          onChange={onRatioChange}
+          disabled={isLoading}
+        />
+      </FormGroup>
+      <FormGroup>
+        <label htmlFor="compressorAttack">Attack: {attack.toFixed(1)} ms</label>
+        <input
+          type="range"
+          id="compressorAttack"
+          min="0.1"
+          max="100" // Adjusted max based on common compressor values
+          step="0.1"
+          value={attack}
+          onChange={onAttackChange}
+          disabled={isLoading}
+        />
+      </FormGroup>
+      <FormGroup>
+        <label htmlFor="compressorRelease">Release: {release.toFixed(0)} ms</label>
+        <input
+          type="range"
+          id="compressorRelease"
+          min="10"
+          max="1000"
+          step="1"
+          value={release}
+          onChange={onReleaseChange}
+          disabled={isLoading}
+        />
+      </FormGroup>
+    </Fieldset>
+  );
+};
+
+export default CompressorControls;

--- a/frontend/react-app/src/components/ReverbControls.js
+++ b/frontend/react-app/src/components/ReverbControls.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { FormGroup, Fieldset } from '../styles/App.styles';
+
+const ReverbControls = ({
+  roomSize, onRoomSizeChange,
+  wetDryMix, onWetDryMixChange,
+  isLoading
+}) => {
+  return (
+    <Fieldset>
+      <legend>Reverb</legend>
+      <FormGroup>
+        <label htmlFor="reverbRoomSize">Room Size: {roomSize.toFixed(2)}</label>
+        <input
+          type="range"
+          id="reverbRoomSize"
+          min="0"
+          max="1"
+          step="0.01"
+          value={roomSize}
+          onChange={onRoomSizeChange}
+          disabled={isLoading}
+        />
+      </FormGroup>
+      <FormGroup>
+        <label htmlFor="reverbWetDryMix">Wet/Dry Mix: {wetDryMix.toFixed(2)}</label>
+        <input
+          type="range"
+          id="reverbWetDryMix"
+          min="0"
+          max="1"
+          step="0.01"
+          value={wetDryMix}
+          onChange={onWetDryMixChange}
+          disabled={isLoading}
+        />
+      </FormGroup>
+    </Fieldset>
+  );
+};
+
+export default ReverbControls;

--- a/frontend/react-app/src/styles/App.styles.js
+++ b/frontend/react-app/src/styles/App.styles.js
@@ -94,6 +94,31 @@ export const Button = styled.button`
 
 // More specific layout components that may use the general ones above
 
+export const EffectsToolsSection = styled(SettingsCardContainer)`
+  h3 {
+    margin-top: 0;
+    margin-bottom: 15px;
+    color: #333;
+    font-size: 1.2rem;
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 10px;
+  }
+`;
+
+export const EffectToggleButton = styled(Button)`
+  margin: 5px;
+  background-color: ${props => props.active ? '#0056b3' : '#6c757d'}; // Darker blue if active, grey otherwise
+  &:hover {
+    background-color: ${props => props.active ? '#004085' : '#5a6268'};
+  }
+  width: calc(50% - 10px); /* Two buttons per row roughly */
+
+  @media (min-width: 500px) { /* Adjust breakpoint as needed */
+    width: calc(33.333% - 10px); /* Three buttons per row */
+  }
+`;
+
+
 export const EQBandControlsGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); /* Responsive grid */
@@ -169,6 +194,9 @@ export const LeftColumn = styled.div`
 
 export const RightColumn = styled.div`
   flex: 2; /* Adjust flex basis as needed */
+  display: flex;
+  flex-direction: column;
+  gap: 20px; /* Adds space between stacked effect modules */
 `;
 
 export const SettingsCardContainer = styled.div`


### PR DESCRIPTION
…b, and Silence Trimming

This commit introduces a new 'Effects & Tools' section and makes several audio processing modules optional and configurable:

1.  **New 'Effects & Tools' UI:**
    *   Added a new card in the Left Column titled 'Effects & Tools'.
    *   Includes toggle buttons for 'Dynamic Equalizer', 'Compressor', and 'Reverb'.
    *   Buttons change style to indicate active state.
    *   Added an 'Automatically Trim Silence' checkbox.

2.  **Dynamic Equalizer Optional:**
    *   The Dynamic Equalizer (AudioControls) is now only displayed in the Right Column if its toggle button is active.

3.  **New Compressor Module:**
    *   Created `CompressorControls.js` with UI for Threshold, Ratio, Attack, and Release.
    *   Conditionally rendered in the Right Column when 'Compressor' is toggled on.
    *   Compressor settings are added to the backend request if the module is active.

4.  **New Reverb Module:**
    *   Created `ReverbControls.js` with UI for Room Size and Wet/Dry Mix.
    *   Conditionally rendered in the Right Column when 'Reverb' is toggled on.
    *   Reverb settings are added to the backend request if the module is active.

5.  **Silence Trimming:**
    *   The 'Automatically Trim Silence' option is included in backend requests.

6.  **State Management & Backend Integration:**
    *   Added state in `App.js` to manage visibility and parameters for new effects.
    *   Updated `handleSubmit` to conditionally include settings for active effects in the FormData sent to the backend.

7.  **Layout Adjustments:**
    *   The Right Column is now a flex container to ensure consistent spacing for multiple active effect modules (EQ, Compressor, Reverb) when stacked vertically.